### PR TITLE
Do not require the TLS Plugin for simulation.

### DIFF
--- a/fdbrpc/TLSConnection.actor.cpp
+++ b/fdbrpc/TLSConnection.actor.cpp
@@ -307,7 +307,7 @@ void TLSOptions::init_plugin( std::string const& plugin_path ) {
 	} else {
 		if ( !platform::getEnvironmentVar( "FDB_TLS_PLUGIN", path ) )
 			// FIXME: should there be other fallbacks?
-			path = platform::getDefaultPluginPath("FDBGnuTLS");
+			path = platform::getDefaultPluginPath("FDBLibTLS");
 	}
 
 	TraceEvent("TLSConnectionLoadingPlugin").detail("PluginPath", path);
@@ -324,4 +324,8 @@ void TLSOptions::init_plugin( std::string const& plugin_path ) {
 		TraceEvent(SevError, "TLSConnectionCreatePolicyError");
 		throw tls_error();
 	}
+}
+
+bool TLSOptions::enabled() {
+	return !!policy;
 }

--- a/fdbrpc/TLSConnection.h
+++ b/fdbrpc/TLSConnection.h
@@ -94,6 +94,7 @@ struct TLSOptions : ReferenceCounted<TLSOptions> {
 	void register_network();
 
 	Reference<ITLSPolicy> get_policy();
+	bool enabled();
 
 private:
 	void init_plugin( std::string const& plugin_path = "" );

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -250,7 +250,9 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(
 				//SOMEDAY: test lower memory limits, without making them too small and causing the database to stop making progress
 				FlowTransport::createInstance(1);
 				Sim2FileSystem::newFileSystem();
-				simInitTLS();
+				if (useSSL) {
+					simInitTLS();
+				}
 				NetworkAddress n(ip, port, true, useSSL);
 				Future<Void> listen = FlowTransport::transport().bind( n, n );
 				Future<Void> fd = fdbd( connFile, localities, processClass, *dataFolder, *coordFolder, 500e6, "", "");
@@ -1135,7 +1137,7 @@ void checkExtraDB(const char *testFile, int &extraDB, int &minimumReplication) {
 	ifs.close();
 }
 
-ACTOR void setupAndRun(std::string dataFolder, const char *testFile, bool rebooting ) {
+ACTOR void setupAndRun(std::string dataFolder, const char *testFile, bool rebooting, bool useSSL ) {
 	state vector<Future<Void>> systemActors;
 	state Optional<ClusterConnectionString> connFile;
 	state Standalone<StringRef> startingConfiguration;
@@ -1148,7 +1150,9 @@ ACTOR void setupAndRun(std::string dataFolder, const char *testFile, bool reboot
 			"TestSystem", 0x01010101, 1, LocalityData(Optional<Standalone<StringRef>>(), Standalone<StringRef>(g_random->randomUniqueID().toString()), Optional<Standalone<StringRef>>(), Optional<Standalone<StringRef>>()), ProcessClass(ProcessClass::TesterClass, ProcessClass::CommandLineSource), "", "" ), TaskDefaultYield ) );
 	Sim2FileSystem::newFileSystem();
 	FlowTransport::createInstance(1);
-	simInitTLS();
+	if (useSSL) {
+		simInitTLS();
+	}
 
 	TEST(true);  // Simulation start
 

--- a/fdbserver/SimulatedCluster.h
+++ b/fdbserver/SimulatedCluster.h
@@ -22,6 +22,6 @@
 #define FDBSERVER_SIMULATEDCLUSTER_H
 #pragma once
 
-void setupAndRun(std::string const& dataFolder, const char* const& testFile, bool const& rebooting);
+void setupAndRun(std::string const& dataFolder, const char* const& testFile, bool const& rebooting, bool const& useSSL);
 
 #endif

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1471,7 +1471,8 @@ int main(int argc, char* argv[]) {
 			if ( tlsVerifyPeers.size() )
 				tlsOptions->set_verify_peers( tlsVerifyPeers );
 
-			tlsOptions->register_network();
+			if (tlsOptions->get_policy())
+				tlsOptions->register_network();
 
 			if (role == FDBD || role == NetworkTestServer) {
 				try {
@@ -1585,7 +1586,7 @@ int main(int argc, char* argv[]) {
 				platform::createDirectory( dataFolder );
 			}
 
-			setupAndRun( dataFolder, testFile, restarting );
+			setupAndRun( dataFolder, testFile, restarting, tlsOptions->enabled() );
 			g_simulator.run();
 		} else if (role == FDBD) {
 			ASSERT( connectionFile );


### PR DESCRIPTION
It appears that explicit calls to TLS-related things had snuck in over time,
which meant that simulation runs that weren't even configured to use SSL still
wanted and required the TLS plugin.

This commit instead threads through the understanding of if any TLS-related
options were provided, and if not, then don't call anything TLS-related so that
we don't require the TLS plugin.

Hopefully this makes life easier for the opensource folk. :)